### PR TITLE
Update to match Node script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "again"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,11 +37,13 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "a75b7e6a93ecd6dbd2c225154d0fa7f86205574ecaa6c87429fb5f66ee677c44"
 dependencies = [
- "const-random",
+ "getrandom 0.2.0",
+ "lazy_static",
+ "version_check",
 ]
 
 [[package]]
@@ -79,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
 
 [[package]]
 name = "arrayref"
@@ -106,13 +102,13 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -140,14 +136,14 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.4.3",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -172,6 +168,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -267,31 +269,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "bzip2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.9+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9c6140b5a2c7db40ea56eb1821245e5362b44385c05b76288b1a599934ac87"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -343,15 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,14 +352,13 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "url 2.2.0",
- "zip",
 ]
 
 [[package]]
 name = "const-random"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
+checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",
@@ -395,19 +366,21 @@ dependencies = [
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
+checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
 dependencies = [
  "getrandom 0.2.0",
+ "lazy_static",
  "proc-macro-hack",
+ "tiny-keccak",
 ]
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "constant_time_eq"
@@ -469,7 +442,7 @@ dependencies = [
  "cranelift-entity",
  "gimli 0.20.0",
  "log",
- "smallvec 1.5.0",
+ "smallvec 1.5.1",
  "target-lexicon 0.10.0",
  "thiserror",
 ]
@@ -518,22 +491,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -544,18 +507,18 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -563,26 +526,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
+name = "crunchy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
- "const_fn",
- "lazy_static",
-]
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
@@ -620,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.38+curl-7.73.0"
+version = "0.4.39+curl-7.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498ecfb4f59997fd40023d62a9f1e506e768b2baeb59a1d311eb9751cdcd7e3f"
+checksum = "07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874"
 dependencies = [
  "cc",
  "libc",
@@ -653,7 +610,7 @@ checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -664,7 +621,7 @@ checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -741,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "log",
 ]
@@ -758,7 +715,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "rustversion",
- "syn 1.0.48",
+ "syn 1.0.54",
  "synstructure",
 ]
 
@@ -801,7 +758,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
  "synstructure",
 ]
 
@@ -844,14 +801,14 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide 0.3.7",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -865,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e818efa7776f4dd7df0e542f877f7a5a87bddd6a1a10f59a7732b71ffb9d55"
+checksum = "1bebadab126f8120d410b677ed95eee4ba6eb7c6dd8e34a5ec88a08050e26132"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -992,7 +949,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "waker-fn",
 ]
 
@@ -1005,7 +962,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -1174,7 +1131,7 @@ dependencies = [
  "paste 1.0.3",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -1506,15 +1463,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "strum",
- "subtle 2.3.0",
+ "subtle 2.4.0",
  "thiserror",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
  "bytes",
  "fnv",
@@ -1640,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -1651,13 +1608,13 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b0b7698c16bccca4617de8f9ede9f58ab44a68ad6b2a4920fd74e491de580d"
+checksum = "514b79a9791d88f90889bd38a88dc43a6058b3ec72a8930a817c6e59fa9e4927"
 dependencies = [
- "ahash 0.4.6",
- "crossbeam-channel 0.4.4",
- "crossbeam-utils 0.7.2",
+ "ahash 0.6.2",
+ "crossbeam-channel",
+ "crossbeam-utils",
  "dashmap",
  "env_logger",
  "indexmap",
@@ -1683,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1707,12 +1664,12 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "isahc"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80aafab09693e9fa74b76ef207c55dc1cba5d9d5dc6dcc1b6a96d008a98000e9"
+checksum = "e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a"
 dependencies = [
  "bytes",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "curl",
  "curl-sys",
  "encoding_rs",
@@ -1747,9 +1704,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1893,15 +1850,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.4+1.41.0"
+version = "0.1.5+1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
+checksum = "9657455ff47889b70ffd37c3e118e8cdd23fd1f9f3293a285f141070621c4c79"
 dependencies = [
  "cc",
  "libc",
@@ -2025,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -2050,15 +2007,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
@@ -2069,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -2080,7 +2028,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2111,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2155,7 +2103,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -2197,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2313,12 +2261,12 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -2333,9 +2281,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2361,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
 ]
@@ -2411,7 +2359,7 @@ checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api 0.4.2",
- "parking_lot_core 0.8.0",
+ "parking_lot_core 0.8.1",
 ]
 
 [[package]]
@@ -2421,25 +2369,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi 0.0.3",
+ "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.5.0",
+ "smallvec 1.5.1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi 0.1.0",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.5.0",
+ "smallvec 1.5.1",
  "winapi 0.3.9",
 ]
 
@@ -2470,11 +2417,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "once_cell",
  "regex",
 ]
@@ -2517,7 +2464,7 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -2528,7 +2475,7 @@ checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -2536,6 +2483,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -2593,7 +2546,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
  "version_check",
 ]
 
@@ -2640,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d72d5477478f85bd00b6521780dfba1ec6cdaadcf90b8b181c36d7de561f9b"
+checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
 dependencies = [
  "memchr",
 ]
@@ -2834,7 +2787,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi 0.0.3",
+ "cloudabi",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -2890,9 +2843,9 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -2974,11 +2927,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2995,7 +2948,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "serde",
  "serde_urlencoded",
  "tokio",
@@ -3018,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.16"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -3073,14 +3026,14 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3295,14 +3248,14 @@ checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3312,14 +3265,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url 2.2.0",
 ]
 
 [[package]]
@@ -3366,7 +3319,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -3406,19 +3359,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "97e0e9fd577458a4f61fb91fcb559ea2afecc54c934119421f9f5d3d5b1a1057"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -3451,9 +3403,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3462,15 +3414,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -3488,7 +3440,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -3499,9 +3451,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
@@ -3516,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3533,7 +3485,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
  "unicode-xid 0.2.1",
 ]
 
@@ -3575,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf11676eb135389f21fcda654382c4859bbfc1d2f36e4425a2f829bb41b1e20e"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -3619,7 +3571,7 @@ checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -3643,10 +3595,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.0.1"
+name = "tiny-keccak"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3659,9 +3620,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes",
  "fnv",
@@ -3674,7 +3635,7 @@ dependencies = [
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -3689,7 +3650,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -3727,7 +3688,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -3764,7 +3725,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3777,7 +3738,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -3848,7 +3809,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.5.0",
+ "smallvec 1.5.1",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -3923,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -4028,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"
@@ -4091,11 +4052,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4103,26 +4064,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4130,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -4140,22 +4101,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
+ "syn 1.0.54",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-timer"
@@ -4206,7 +4167,7 @@ checksum = "c23f2824f354a00a77e4b040eef6e1d4c595a8a3e9013bad65199cc8dade9a5a"
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.5.0",
+ "smallvec 1.5.1",
  "target-lexicon 0.10.0",
 ]
 
@@ -4287,9 +4248,9 @@ checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4297,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -4383,18 +4344,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 dependencies = [
  "chrono",
-]
-
-[[package]]
-name = "zip"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543adf038106b64cfca4711c82c917d785e3540e04f7996554488f988ec43124"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "flate2",
- "thiserror",
- "time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "holochain_serialized_bytes 0.0.46",
  "lazy_static",
@@ -1269,7 +1269,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "holochain_zome_types",
  "paste 1.0.3",
@@ -1320,7 +1320,7 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1337,7 +1337,7 @@ dependencies = [
 [[package]]
 name = "holochain"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "holochain_keystore"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "ghost_actor",
  "holo_hash",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "holochain_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "async-trait",
  "fixt",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "holochain_state"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "holochain_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_test_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1622,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "holochain_websocket"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "futures",
  "holochain_serialized_bytes 0.0.46",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "derive_more",
  "fixt",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_proxy"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_transport_quic"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "futures",
  "if-addrs",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "derive_more",
  "futures",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "test_wasm_common"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
+source = "git+https://github.com/holochain/holochain?rev=43210e7360970369025e7a6e528779d8f9636564#43210e7360970369025e7a6e528779d8f9636564"
 dependencies = [
  "hdk3",
  "holochain_serialized_bytes 0.0.46",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "again"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05802a5ad4d172eaf796f7047b42d0af9db513585d16d4169660a21613d34b93"
+dependencies = [
+ "log",
+ "rand 0.7.3",
+ "wasm-timer",
+]
+
+[[package]]
 name = "ahash"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +338,15 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
 ]
@@ -790,7 +810,7 @@ source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.10.2",
  "paste 1.0.3",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -1214,7 +1234,7 @@ dependencies = [
  "nanoid",
  "num_cpus",
  "observability",
- "parking_lot",
+ "parking_lot 0.10.2",
  "predicates",
  "rand 0.7.3",
  "ring",
@@ -1328,7 +1348,7 @@ dependencies = [
  "lazy_static",
  "must_future",
  "nanoid",
- "parking_lot",
+ "parking_lot 0.10.2",
  "rand 0.7.3",
  "rkv",
  "rmp-serde",
@@ -2357,7 +2377,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api 0.3.4",
- "parking_lot_core",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api 0.4.2",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -2367,7 +2398,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.5.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec 1.5.0",
@@ -2765,7 +2811,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -3170,6 +3216,7 @@ dependencies = [
 name = "self-hosted-happs"
 version = "0.1.0"
 dependencies = [
+ "again",
  "anyhow",
  "futures",
  "holochain",
@@ -4111,6 +4158,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.1",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmer-clif-backend"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,7 +4255,7 @@ dependencies = [
  "libc",
  "nix",
  "page_size",
- "parking_lot",
+ "parking_lot 0.10.2",
  "rustc_version",
  "serde",
  "serde-bench",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "again"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,7 +223,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -223,10 +232,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -237,6 +246,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
@@ -287,6 +302,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
+dependencies = [
+ "cipher",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fc18e6d90c40164bf6c317476f2a98f04661e310e79830366b7e914c58a8e"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +355,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -419,6 +466,12 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
@@ -547,8 +600,22 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42152c7961cd7af77bfe71c2cb0cf893b0a8939e9510d0c4db9b8d9027fea7e4"
+dependencies = [
+ "chacha20poly1305",
+ "rand_core 0.5.1",
+ "salsa20",
+ "x25519-dalek",
+ "xsalsa20poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -592,6 +659,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle 2.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "strsim 0.9.3",
+ "syn 1.0.54",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
 name = "dashmap"
 version = "3.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +723,31 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.54",
@@ -636,7 +776,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -786,9 +935,9 @@ dependencies = [
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "lazy_static",
  "parking_lot 0.10.2",
  "paste 1.0.3",
@@ -1029,6 +1178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,7 +1269,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -1125,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "holochain_zome_types",
  "paste 1.0.3",
@@ -1161,13 +1320,13 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
  "fixt",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "must_future",
  "rand 0.7.3",
  "serde",
@@ -1178,7 +1337,7 @@ dependencies = [
 [[package]]
 name = "holochain"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1198,7 +1357,7 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_state",
  "holochain_types",
  "holochain_wasm_test_utils",
@@ -1206,6 +1365,7 @@ dependencies = [
  "holochain_websocket",
  "holochain_zome_types",
  "human-panic",
+ "itertools 0.9.0",
  "kitsune_p2p",
  "lazy_static",
  "matches",
@@ -1242,11 +1402,11 @@ dependencies = [
 [[package]]
 name = "holochain_keystore"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "ghost_actor",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_zome_types",
  "lair_keystore_api",
  "lair_keystore_client",
@@ -1260,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "holochain_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "async-trait",
  "fixt",
@@ -1268,7 +1428,7 @@ dependencies = [
  "ghost_actor",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_types",
  "holochain_zome_types",
  "kitsune_p2p",
@@ -1288,7 +1448,22 @@ version = "0.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adca869d80860a04757af4fc011d49505594365391a6e3a04105e8f88b9c32e1"
 dependencies = [
- "holochain_serialized_bytes_derive",
+ "holochain_serialized_bytes_derive 0.0.45",
+ "rmp-serde",
+ "serde",
+ "serde-transcode",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "holochain_serialized_bytes"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8fe6bc8c830633862ee0b7903706f6d940f7c794b3f5e768f660a7abbacbc9"
+dependencies = [
+ "holochain_serialized_bytes_derive 0.0.46",
  "rmp-serde",
  "serde",
  "serde-transcode",
@@ -1308,9 +1483,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "holochain_serialized_bytes_derive"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a4c0ef882177ac63c8912ae9c1eb6285d3b50a56f2bb0cebc41012255b7734"
+dependencies = [
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "holochain_state"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1323,7 +1508,7 @@ dependencies = [
  "futures",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_types",
  "lazy_static",
  "must_future",
@@ -1346,20 +1531,21 @@ dependencies = [
 [[package]]
 name = "holochain_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "anyhow",
  "async-trait",
  "backtrace",
  "base64 0.10.1",
  "chrono",
+ "derive_builder",
  "derive_more",
  "fixt",
  "flate2",
  "futures",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_zome_types",
  "lazy_static",
  "must_future",
@@ -1383,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_test_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1399,33 +1585,33 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.50"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfcc07f0ff0aa409a6f7b1fd4766c3c31c6e47a0a7b74563bff5e8791378277"
+checksum = "5e064411f7c8cf58e08a451c2df9ab99efb5de839f74a650c1a30abbd607add8"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.50"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924a5024a73c73d8835594db1978a4c830ebd51c396920f91a58d7c9ef85641b"
+checksum = "6c86bf521e02f8f86ea96177ef316560e66e51a192b83a302e8e4b32a6f47f02"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_wasmer_common",
  "serde",
 ]
 
 [[package]]
 name = "holochain_wasmer_host"
-version = "0.0.50"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a094cb028913a2d112d2db4d54968b5380ad881ca9c7653dff699d8fb91c4759"
+checksum = "2148dc74f406813bd43ea16424aee613c1150cac9585cf4aad2f54ec9aa08461"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "holochain_wasmer_common",
  "lazy_static",
  "serde",
@@ -1436,10 +1622,10 @@ dependencies = [
 [[package]]
 name = "holochain_websocket"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "nanoid",
  "net2",
  "serde",
@@ -1455,11 +1641,12 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "fixt",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
+ "paste 1.0.3",
  "serde",
  "serde_bytes",
  "strum",
@@ -1551,6 +1738,12 @@ dependencies = [
  "tokio",
  "tokio-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1697,6 +1890,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "derive_more",
  "fixt",
@@ -1749,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_proxy"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1759,6 +1961,7 @@ dependencies = [
  "kitsune_p2p_types",
  "lair_keystore_api",
  "nanoid",
+ "observability",
  "rmp-serde",
  "rustls 0.18.1",
  "serde",
@@ -1772,13 +1975,14 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_transport_quic"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "futures",
  "if-addrs",
  "kitsune_p2p_types",
  "lair_keystore_api",
  "nanoid",
+ "once_cell",
  "quinn",
  "rcgen",
  "rustls 0.17.0",
@@ -1790,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "derive_more",
  "futures",
@@ -1808,12 +2012,14 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.0.1-alpha.8"
+version = "0.0.1-alpha.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e635eb7138566c139cd28b63e9d5983292c8e0e7576b3cda1fcfa32b3127717"
+checksum = "9e29ec57903c6fcac8d0994f03b9d6cdcd7f879748ee02de653b8a161302060e"
 dependencies = [
  "blake2b_simd",
+ "block-padding 0.2.1",
  "byteorder",
+ "crypto_box",
  "derive_more",
  "directories 3.0.1",
  "futures",
@@ -1821,9 +2027,11 @@ dependencies = [
  "nanoid",
  "num_cpus",
  "once_cell",
+ "rand 0.7.3",
  "rayon",
  "rcgen",
  "ring",
+ "subtle 2.4.0",
  "thiserror",
  "tokio",
  "toml",
@@ -1831,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_client"
-version = "0.0.1-alpha.8"
+version = "0.0.1-alpha.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573c0df3428bca8176fc287a26f8fa986408dc5ced8ad90a31a98f850594aaac"
+checksum = "61ee943659739a639033086b421eb19c155c9a8a64c64a6e37e1025ce5651bb2"
 dependencies = [
  "ghost_actor",
  "lair_keystore_api",
@@ -2232,7 +2440,7 @@ checksum = "9b7f7ad81f5735063ff3efaf54fe1a503b64f34aefa5452d0543c71a722a03e7"
 dependencies = [
  "chrono",
  "derive_more",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.45",
  "inferno",
  "once_cell",
  "opentelemetry",
@@ -2501,6 +2709,16 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "poly1305"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+dependencies = [
+ "cpuid-bool",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3102,6 +3320,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "salsa20"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
+dependencies = [
+ "cipher",
+ "zeroize",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,7 +3522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
  "block-buffer",
- "digest",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
 ]
@@ -3316,7 +3544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
  "bitflags",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.54",
@@ -3400,6 +3628,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
@@ -3537,10 +3771,10 @@ dependencies = [
 [[package]]
 name = "test_wasm_common"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+source = "git+https://github.com/holochain/holochain?rev=6bd822cf3378178b5600ab79d8560f04b5a5b837#6bd822cf3378178b5600ab79d8560f04b5a5b837"
 dependencies = [
  "hdk3",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.46",
  "serde",
  "serde_bytes",
 ]
@@ -3907,6 +4141,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.4.0",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,7 +4452,7 @@ dependencies = [
  "bincode",
  "blake3",
  "cc",
- "digest",
+ "digest 0.8.1",
  "errno",
  "hex",
  "indexmap",
@@ -4329,6 +4573,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0304c336e98d753428f7b3d8899d60b8a87a961ef50bdfc44af0c1bea2651ce5"
+dependencies = [
+ "aead",
+ "poly1305",
+ "rand_core 0.5.1",
+ "salsa20",
+ "subtle 2.4.0",
+ "zeroize",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,4 +4613,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+ "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,12 +786,12 @@ dependencies = [
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
  "parking_lot",
- "paste 1.0.2",
+ "paste 1.0.3",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -1007,6 +1007,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,12 +1052,13 @@ dependencies = [
 
 [[package]]
 name = "ghost_actor"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7af7fc240a7e45b281fa1babdf35b7716f5244ab905d8c960ed190ab15f70b"
+checksum = "6d5180a86962ed70e36dd39b469d1c17d1a4cfefa610e63be5bbb10a4cec9bcc"
 dependencies = [
  "futures",
  "must_future",
+ "observability",
  "paste 0.1.18",
  "thiserror",
  "tracing",
@@ -1094,6 +1108,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "hdk3"
+version = "0.0.1"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+dependencies = [
+ "hdk3_derive",
+ "holo_hash",
+ "holochain_wasmer_guest",
+ "holochain_zome_types",
+ "paste 1.0.3",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+]
+
+[[package]]
+name = "hdk3_derive"
+version = "0.0.1"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+dependencies = [
+ "holochain_zome_types",
+ "paste 1.0.3",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,7 +1161,7 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1137,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "holochain"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1153,9 +1194,9 @@ dependencies = [
  "fixt",
  "futures",
  "ghost_actor",
+ "hdk3",
  "holo_hash",
  "holochain_keystore",
- "holochain_legacy",
  "holochain_p2p",
  "holochain_serialized_bytes",
  "holochain_state",
@@ -1167,6 +1208,7 @@ dependencies = [
  "human-panic",
  "kitsune_p2p",
  "lazy_static",
+ "matches",
  "mockall",
  "must_future",
  "nanoid",
@@ -1183,12 +1225,14 @@ dependencies = [
  "structopt",
  "strum",
  "tempdir",
+ "test_wasm_common",
  "thiserror",
  "tokio",
  "tokio_safe_block_on",
  "toml",
  "tracing",
  "tracing-futures",
+ "unwrap_to",
  "url 1.7.2",
  "url2",
  "url_serde",
@@ -1198,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "holochain_keystore"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "ghost_actor",
  "holo_hash",
@@ -1214,18 +1258,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "holochain_legacy"
-version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
-dependencies = [
- "holochain_serialized_bytes",
- "serde",
-]
-
-[[package]]
 name = "holochain_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "async-trait",
  "fixt",
@@ -1275,7 +1310,7 @@ dependencies = [
 [[package]]
 name = "holochain_state"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1311,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "holochain_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1348,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_test_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1364,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.47"
+version = "0.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c7be01e9d8b4e42529fcb2b4f5f550cb57430675573c303b52466757be1df0"
+checksum = "edfcc07f0ff0aa409a6f7b1fd4766c3c31c6e47a0a7b74563bff5e8791378277"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -1374,10 +1409,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "holochain_wasmer_host"
-version = "0.0.47"
+name = "holochain_wasmer_guest"
+version = "0.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c80f132d55adbcd7e29f6af7181932f0cd51cec3d4c292ab7f9f13903c8db"
+checksum = "924a5024a73c73d8835594db1978a4c830ebd51c396920f91a58d7c9ef85641b"
+dependencies = [
+ "holochain_serialized_bytes",
+ "holochain_wasmer_common",
+ "serde",
+]
+
+[[package]]
+name = "holochain_wasmer_host"
+version = "0.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a094cb028913a2d112d2db4d54968b5380ad881ca9c7653dff699d8fb91c4759"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -1390,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "holochain_websocket"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "futures",
  "holochain_serialized_bytes",
@@ -1409,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1678,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "derive_more",
  "fixt",
@@ -1688,6 +1734,7 @@ dependencies = [
  "kitsune_p2p_transport_quic",
  "kitsune_p2p_types",
  "lair_keystore_api",
+ "observability",
  "once_cell",
  "rand 0.7.3",
  "reqwest",
@@ -1702,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_proxy"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1725,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_transport_quic"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "futures",
  "if-addrs",
@@ -1743,14 +1790,14 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 dependencies = [
  "derive_more",
  "futures",
  "ghost_actor",
  "nanoid",
  "once_cell",
- "paste 1.0.2",
+ "paste 1.0.3",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1761,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.0.1-alpha.7"
+version = "0.0.1-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424950ea71dfa85289cefda13ef8f89d29f1fce71728807b810a69edfed213fa"
+checksum = "6e635eb7138566c139cd28b63e9d5983292c8e0e7576b3cda1fcfa32b3127717"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1784,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_client"
-version = "0.0.1-alpha.7"
+version = "0.0.1-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df55a917ffb484763d0067b4305dafe2677778e2aa775a9d202f41e1cc6101eb"
+checksum = "573c0df3428bca8176fc287a26f8fa986408dc5ced8ad90a31a98f850594aaac"
 dependencies = [
  "ghost_actor",
  "lair_keystore_api",
@@ -1881,6 +1928,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2176,15 +2236,22 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 [[package]]
 name = "observability"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain?rev=ddda96773b3e97f658ed46f2400ff8d0183be3fd#ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7f7ad81f5735063ff3efaf54fe1a503b64f34aefa5452d0543c71a722a03e7"
 dependencies = [
  "chrono",
+ "derive_more",
+ "holochain_serialized_bytes",
  "inferno",
+ "once_cell",
+ "opentelemetry",
+ "serde",
+ "serde_bytes",
  "serde_json",
  "thiserror",
  "tracing",
  "tracing-core",
- "tracing-flame",
+ "tracing-opentelemetry",
  "tracing-serde",
  "tracing-subscriber",
 ]
@@ -2232,6 +2299,21 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf68b6b34b5d869342732c0dc05f74b7bdb4f17f2302d16d799231a6106441"
+dependencies = [
+ "bincode",
+ "futures",
+ "lazy_static",
+ "percent-encoding 2.1.0",
+ "pin-project 0.4.27",
+ "rand 0.7.3",
+ "serde",
 ]
 
 [[package]]
@@ -2304,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7ae1a2180ed02ddfdb5ab70c70d596a26dd642e097bb6fe78b1bde8588ed97"
+checksum = "7151b083b0664ed58ed669fcdd92f01c3d2fdbf10af4931a301474950b52bfa9"
 
 [[package]]
 name = "paste-impl"
@@ -3017,6 +3099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,11 +3301,12 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
 dependencies = [
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -3447,6 +3536,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_wasm_common"
+version = "0.0.1"
+source = "git+https://github.com/holochain/holochain?rev=feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb#feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+dependencies = [
+ "hdk3",
+ "holochain_serialized_bytes",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,12 +3711,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3634,22 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.13"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d593f98af59ebc017c0648f0117525db358745a8894a8d684e185ba3f45954f9"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-flame"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd520fe41c667b437952383f3a1ec14f1fa45d653f719a77eedd6e6a02d8fa54"
-dependencies = [
- "lazy_static",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3674,10 +3764,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.1"
+name = "tracing-opentelemetry"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+checksum = "8aba1fbd3e3152340cfa12087759543277affcce4a40a659bdb5ec21f725d3d6"
+dependencies = [
+ "opentelemetry",
+ "rand 0.7.3",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
@@ -3685,9 +3789,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b33f8b2ef2ab0c3778c12646d9c42a24f7772bee4cdafc72199644a9f58fdc"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3698,6 +3802,8 @@ dependencies = [
  "serde_json",
  "sharded-slab",
  "smallvec 1.5.0",
+ "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3797,6 +3903,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "unwrap_to"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad414b2eed757c1b6f810f8abc814e298a9c89176b21fae092c7a87756fb839"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "configure-holochain"
+version = "0.1.0"
+dependencies = [
+ "again",
+ "anyhow",
+ "futures",
+ "holochain",
+ "holochain_types",
+ "holochain_websocket",
+ "isahc",
+ "serde",
+ "serde_yaml",
+ "structopt",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
+ "url 2.2.0",
+ "zip",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,29 +3233,6 @@ checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys 0.8.2",
  "libc",
-]
-
-[[package]]
-name = "self-hosted-happs"
-version = "0.1.0"
-dependencies = [
- "again",
- "anyhow",
- "futures",
- "holochain",
- "holochain_types",
- "holochain_websocket",
- "isahc",
- "serde",
- "serde_yaml",
- "structopt",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-futures",
- "tracing-subscriber",
- "url 2.2.0",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ url = "2.2"
 
 [dependencies.holochain]
 git = "https://github.com/holochain/holochain"
-rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837"
+rev = "43210e7360970369025e7a6e528779d8f9636564"
 package = "holochain"
 
 [dependencies.holochain_types]
 git = "https://github.com/holochain/holochain"
-rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837"
+rev = "43210e7360970369025e7a6e528779d8f9636564"
 package = "holochain_types"
 
 [dependencies.holochain_websocket]
 git = "https://github.com/holochain/holochain"
-rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837"
+rev = "43210e7360970369025e7a6e528779d8f9636564"
 package = "holochain_websocket"
 
 # Holochain requires a patch to crates.io registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ zip = "0.5"
 
 [dependencies.holochain]
 git = "https://github.com/holochain/holochain"
-rev = "ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 package = "holochain"
 
 [dependencies.holochain_types]
 git = "https://github.com/holochain/holochain"
-rev = "ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 package = "holochain_types"
 
 [dependencies.holochain_websocket]
 git = "https://github.com/holochain/holochain"
-rev = "ddda96773b3e97f658ed46f2400ff8d0183be3fd"
+rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
 package = "holochain_websocket"
 
 # Holochain requires a patch to crates.io registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
 url = "2.2"
-zip = "0.5"
 
 [dependencies.holochain]
 git = "https://github.com/holochain/holochain"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "self-hosted-happs"
+name = "configure-holochain"
 version = "0.1.0"
 authors = ["Oleksii Filonenko <oleksii.filonenko@holo.host>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ url = "2.2"
 
 [dependencies.holochain]
 git = "https://github.com/holochain/holochain"
-rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837"
 package = "holochain"
 
 [dependencies.holochain_types]
 git = "https://github.com/holochain/holochain"
-rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837"
 package = "holochain_types"
 
 [dependencies.holochain_websocket]
 git = "https://github.com/holochain/holochain"
-rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb"
+rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837"
 package = "holochain_websocket"
 
 # Holochain requires a patch to crates.io registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Oleksii Filonenko <oleksii.filonenko@holo.host>"]
 edition = "2018"
 
 [dependencies]
+again = "0.1"
 anyhow = "1.0"
 futures = "0.3"
 isahc = "0.9"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,30 @@ ARGS:
 where file at `happ-list-path` is of a format:
 
 ```yaml
+core_happs: [Happ]
+self_hosted_happs: [Happ]
+```
+
+where `Happ` is
+
+```yaml
+app_id: string
+version: string
+dna_url: string (optional)
+ui_url: string (optional)
+```
+
+Example YAML:
+
+```yaml
 ---
-- app_id: elemental-chat
-  version: 1
-  ui_url: https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha7/elemental-chat.zip
-  dna_url: https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz
+core_happs:
+  - app_id: hha
+    version: 1
+    dna_url: https://s3.eu-central-1.wasabisys.com/elemetal-chat-tests/hha.dna.gz
+self_hosted_happs:
+  - app_id: elemental-chat
+    version: 1
+    dna_url: https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz
+    ui_url: https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha7/elemental-chat.zip
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # hpos-configure-holochain
-Install self-hosted hApps from a YAML file into holochain
+Installs apps in holochain and downloads UI in the `UI_STORE_FOLDER` directory from a YAML configuration file.
 
 ## Usage
 
 ```
 $ hpos-configure-holochain --help
 USAGE:
-    self-hosted-happs [OPTIONS] <happ-list-path> --ui-store-folder <ui-store-folder>
+    hpos-configure-holochain [OPTIONS] <happ-list-path> --ui-store-folder <ui-store-folder>
 
 FLAGS:
     -h, --help       Prints help information
@@ -23,11 +23,11 @@ ARGS:
 
 ```
 
-where `happ-list-path` is of a format:
+where file at `happ-list-path` is of a format:
 
 ```yaml
 ---
-- installed_app_id: elemental-chat
+- app_id: elemental-chat
   version: 1
   ui_url: https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha7/elemental-chat.zip
   dna_url: https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz

--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
-# self-hosted-happs
+# hpos-configure-holochain
 Install self-hosted hApps from a YAML file into holochain
 
 ## Usage
 
 ```
-self-hosted-happs config.yaml
+$ hpos-configure-holochain --help
+USAGE:
+    self-hosted-happs [OPTIONS] <happ-list-path> --ui-store-folder <ui-store-folder>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --admin-port <admin-port>              Holochain conductor port [env: ADMIN_PORT=]  [default: 4444]
+        --happ-port <happ-port>                hApp listening port [env: HAPP_PORT=]  [default: 42233]
+        --ui-store-folder <ui-store-folder>    Path to the folder where hApp UIs will be extracted [env:
+                                               UI_STORE_FOLDER=]
+
+ARGS:
+    <happ-list-path>    Path to a YAML file containing the list of hApps to install
+
 ```
 
-where `config.yaml` is of a format `[{app_id, ui_url, dna_url}]`:
+where `happ-list-path` is of a format:
 
 ```yaml
 ---
-- app_id: elemental-chat
-  ui_url: https://s3.eu-central-1.wasabisys.com/elemetal-chat-tests/elemental-chat.zip
-  dna_url: https://s3.eu-central-1.wasabisys.com/elemetal-chat-tests/elemental-chat.dna.gz
+- installed_app_id: elemental-chat
+  version: 1
+  ui_url: https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha7/elemental-chat.zip
+  dna_url: https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz
 ```
-
-All options can be set as a CLI flag or an environment variable.
-See `self-hosted-happs --help` for information on what options are available.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-stable-2020-08-03
+stable

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,7 @@ impl Config {
 #[derive(Debug, Deserialize)]
 pub struct Happ {
     #[serde(alias = "app_id")]
-    pub installed_app_id: InstalledAppId,
+    pub app_id: InstalledAppId,
     pub version: String,
     pub ui_url: Option<Url>,
     pub dna_url: Option<Url>,
@@ -42,6 +42,6 @@ pub struct Happ {
 
 impl Happ {
     pub fn id_with_version(&self) -> String {
-        format!("{}:{}", self.installed_app_id, self.version)
+        format!("{}:{}", self.app_id, self.version)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     #[structopt(long, env, default_value = "42233")]
     pub happ_port: u16,
     /// Path to the folder where hApp UIs will be extracted
-    #[structopt(long, env, default_value = "./self-hosted-happs/uis")]
+    #[structopt(long, env)]
     pub ui_store_folder: PathBuf,
     /// Path to a YAML file containing the list of hApps to install
     pub happ_list_path: PathBuf,
@@ -33,7 +33,14 @@ impl Config {
 /// Configuration of a single hApp from config.yaml
 #[derive(Debug, Deserialize)]
 pub struct Happ {
-    pub app_id: AppId,
+    pub installed_app_id: InstalledAppId,
+    pub version: String,
     pub ui_url: Url,
     pub dna_url: Url,
+}
+
+impl Happ {
+    pub fn id_with_version(&self) -> String {
+        format!("{}:{}", self.installed_app_id, self.version)
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     #[structopt(long, env)]
     pub ui_store_folder: PathBuf,
     /// Path to a YAML file containing the list of hApps to install
-    pub happ_list_path: PathBuf,
+    pub happ_file_path: PathBuf,
 }
 
 impl Config {
@@ -28,6 +28,12 @@ impl Config {
         debug!(?config, "loaded");
         config
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HappFile {
+    pub self_hosted_happs: Vec<Happ>,
+    pub core_happs: Vec<Happ>,
 }
 
 /// Configuration of a single hApp from config.yaml

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use holochain_types::app::AppId;
+use holochain_types::app::InstalledAppId;
 use serde::Deserialize;
 use structopt::StructOpt;
 use tracing::debug;

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,8 +35,8 @@ impl Config {
 pub struct Happ {
     pub installed_app_id: InstalledAppId,
     pub version: String,
-    pub ui_url: Url,
-    pub dna_url: Url,
+    pub ui_url: Option<Url>,
+    pub dna_url: Option<Url>,
 }
 
 impl Happ {

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ impl Config {
 /// Configuration of a single hApp from config.yaml
 #[derive(Debug, Deserialize)]
 pub struct Happ {
+    #[serde(alias = "app_id")]
     pub installed_app_id: InstalledAppId,
     pub version: String,
     pub ui_url: Option<Url>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub(crate) fn extract_zip<P: AsRef<Path>>(source_path: P, unpack_path: P) -> Res
     fs::create_dir(unpack_path.as_ref()).context("failed to create empty unpack_path")?;
 
     process::Command::new("unzip")
+        .arg("-qq")
         .arg(source_path.as_ref().as_os_str())
         .arg("-d")
         .arg(unpack_path.as_ref().as_os_str())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub fn load_happ_file(path: impl AsRef<Path>) -> Result<HappFile> {
 
     let file = File::open(path).context("failed to open file")?;
     let happ_file =
-        serde_yaml::from_reader(&file).context("failed to deserialize YAML as Vec<Happ>")?;
+        serde_yaml::from_reader(&file).context("failed to deserialize YAML as HappFile")?;
     debug!(?happ_file);
     Ok(happ_file)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub async fn install_happs(happ_list: &[Happ], config: &Config) -> Result<()> {
             async move {
                 let install_ui = install_ui(happ, config);
                 if installed_happs.contains(&happ.id_with_version()) {
-                    info!(?happ.installed_app_id, "already installed, just downloading UI");
+                    info!(?happ.app_id, "already installed, just downloading UI");
                     install_ui.await
                 } else {
                     let install_happ = admin_websocket.install_happ(happ, agent_key);
@@ -77,20 +77,20 @@ pub async fn install_happs(happ_list: &[Happ], config: &Config) -> Result<()> {
 #[instrument(
     err,
     skip(happ, config),
-    fields(?happ.installed_app_id)
+    fields(?happ.app_id)
 )]
 async fn install_ui(happ: &Happ, config: &Config) -> Result<()> {
     if happ.ui_url.is_none() {
-        debug!(?happ.installed_app_id, "ui_url == None, skipping UI installation");
+        debug!(?happ.app_id, "ui_url == None, skipping UI installation");
         return Ok(());
     }
 
     let source_path = download_file(happ.ui_url.as_ref().unwrap())
         .await
         .context("failed to download UI archive")?;
-    let unpack_path = config.ui_store_folder.join(&happ.installed_app_id);
+    let unpack_path = config.ui_store_folder.join(&happ.app_id);
     extract_zip(&source_path, &unpack_path).context("failed to extract UI archive")?;
-    info!(?happ.installed_app_id, "installed UI");
+    info!(?happ.app_id, "installed UI");
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,12 @@ pub async fn install_happs(happ_list: &[Happ], config: &Config) -> Result<()> {
     fields(?happ.installed_app_id)
 )]
 async fn install_ui(happ: &Happ, config: &Config) -> Result<()> {
-    let mut ui_archive = download_file(&happ.ui_url)
+    if happ.ui_url.is_none() {
+        debug!(?happ.installed_app_id, "ui_url == None, skipping UI installation");
+        return Ok(());
+    }
+
+    let mut ui_archive = download_file(happ.ui_url.as_ref().unwrap())
         .await
         .context("failed to download UI archive")?;
     let unpack_path = config.ui_store_folder.join(&happ.installed_app_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,12 @@ pub(crate) async fn download_file(url: &Url) -> Result<PathBuf> {
     let mut response = client
         .get(url.as_str())
         .context("failed to send GET request")?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "response status code {} indicated failure",
+            response.status().as_str()
+        ));
+    }
     let dir = TempDir::new().context("failed to create tempdir")?;
     let url_path = PathBuf::from(url.path());
     let basename = url_path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
-use futures::future::try_join_all;
+use futures::future;
 use tempfile::NamedTempFile;
 use tracing::{debug, info, instrument, trace, warn};
 use url::Url;
@@ -35,8 +35,8 @@ pub async fn install_happs(happ_list: &[Happ], config: &Config) -> Result<()> {
         .await
         .context("failed to connect to holochain")?;
 
-    if let Err(e) = admin_websocket.attach_app_interface(config.happ_port).await {
-        warn!(port = ?config.happ_port, "failed to start interface, maybe it's already up?");
+    if let Err(error) = admin_websocket.attach_app_interface(config.happ_port).await {
+        warn!(port = ?config.happ_port, ?error, "failed to start interface, maybe it's already up?");
     }
 
     let agent_key = admin_websocket
@@ -69,11 +69,9 @@ pub async fn install_happs(happ_list: &[Happ], config: &Config) -> Result<()> {
             }
         })
         .collect();
-    let _: Vec<_> = try_join_all(futures)
-        .await
-        .context("failed to install some hApps")?;
+    let _: Vec<_> = future::join_all(futures).await;
 
-    info!("all hApps installed");
+    info!("finished installing hApps");
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,15 +80,15 @@ pub async fn install_happs(happ_list: &[Happ], config: &Config) -> Result<()> {
 #[instrument(
     err,
     skip(happ, config),
-    fields(?happ.app_id)
+    fields(?happ.installed_app_id)
 )]
 async fn install_ui(happ: &Happ, config: &Config) -> Result<()> {
     let mut ui_archive = download_file(&happ.ui_url)
         .await
         .context("failed to download UI archive")?;
-    let unpack_path = config.ui_store_folder.join(&happ.app_id);
+    let unpack_path = config.ui_store_folder.join(&happ.installed_app_id);
     extract_zip(ui_archive.as_file_mut(), unpack_path).context("failed to extract UI archive")?;
-    info!(?happ.app_id, "installed UI");
+    info!(?happ.installed_app_id, "installed UI");
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,8 @@ async fn install_ui(happ: &Happ, config: &Config) -> Result<()> {
 
 #[instrument]
 pub(crate) async fn download_file(url: &Url) -> Result<PathBuf> {
-    use isahc::prelude::*;
     use isahc::config::RedirectPolicy;
+    use isahc::prelude::*;
 
     debug!("downloading");
     let mut url = Url::clone(&url);
@@ -107,7 +107,8 @@ pub(crate) async fn download_file(url: &Url) -> Result<PathBuf> {
         .redirect_policy(RedirectPolicy::Follow)
         .build()
         .context("failed to initiate download request")?;
-    let mut response = client.get(url.as_str())
+    let mut response = client
+        .get(url.as_str())
         .context("failed to send GET request")?;
     let dir = TempDir::new().context("failed to create tempdir")?;
     let url_path = PathBuf::from(url.path());

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 
-use configure_holochain::{install_happs, load_happs_yaml, Config};
+use configure_holochain::{install_happs, load_happ_file, Config};
 use tracing::instrument;
 use tracing_subscriber::EnvFilter;
 
@@ -17,8 +17,8 @@ async fn main() -> Result<()> {
 #[instrument(err)]
 async fn run() -> Result<()> {
     let config = Config::load();
-    let happ_list =
-        load_happs_yaml(&config.happ_list_path).context("failed to load hApps YAML config")?;
-    install_happs(&happ_list, &config).await?;
+    let happ_file =
+        load_happ_file(&config.happ_file_path).context("failed to load hApps YAML config")?;
+    install_happs(&happ_file, &config).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,12 @@ use anyhow::{Context, Result};
 
 use self_hosted_happs::{install_happs, load_happs_yaml, Config};
 use tracing::instrument;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    let filter = EnvFilter::from_default_env().add_directive("again=trace".parse().unwrap());
+    tracing_subscriber::fmt().with_env_filter(filter).init();
     run().await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 
-use self_hosted_happs::{install_happs, load_happs_yaml, Config};
+use configure_holochain::{install_happs, load_happs_yaml, Config};
 use tracing::instrument;
 use tracing_subscriber::EnvFilter;
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -85,12 +85,12 @@ impl AdminWebsocket {
         happ: &Happ,
         agent_key: AgentPubKey,
     ) -> Result<AdminResponse> {
-        let file = crate::download_file(happ.dna_url.as_ref().context("dna_url is None")?)
+        let path = crate::download_file(happ.dna_url.as_ref().context("dna_url is None")?)
             .await
             .context("failed to download DNA archive")?;
         let dna = InstallAppDnaPayload {
             nick: happ.id_with_version(),
-            path: file.path().to_path_buf(),
+            path,
             properties: None,
             membrane_proof: None,
         };

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -70,7 +70,7 @@ impl AdminWebsocket {
     #[instrument(
         err,
         skip(self, happ, agent_key),
-        fields(?happ.app_id)
+        fields(?happ.installed_app_id)
     )]
     async fn instance_dna_for_agent(
         &mut self,

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -74,7 +74,7 @@ impl AdminWebsocket {
     )]
     pub async fn install_happ(&mut self, happ: &Happ) -> Result<()> {
         if happ.dna_url.is_some() {
-            self.instance_dna_for_agent(happ).await?;
+            self.install_dna(happ).await?;
         } else {
             debug!(?happ.app_id, "dna_url == None, skipping DNA installation")
         }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -23,7 +23,11 @@ impl AdminWebsocket {
         let url = format!("ws://localhost:{}/", admin_port);
         let url = Url::parse(&url).context("invalid ws:// URL")?;
         let websocket_config = Arc::new(WebsocketConfig::default());
-        let (tx, _rx) = websocket_connect(url.clone().into(), websocket_config).await?;
+        let (tx, _rx) = again::retry(|| {
+            let websocket_config = Arc::clone(&websocket_config);
+            websocket_connect(url.clone().into(), websocket_config)
+        })
+        .await?;
         Ok(Self { tx })
     }
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -88,7 +88,7 @@ impl AdminWebsocket {
         skip(self, happ),
         fields(?happ.app_id)
     )]
-    async fn instance_dna_for_agent(&mut self, happ: &Happ) -> Result<AdminResponse> {
+    async fn install_dna(&mut self, happ: &Happ) -> Result<AdminResponse> {
         let agent_key = self
             .get_agent_key()
             .await

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -40,7 +40,7 @@ impl AdminWebsocket {
         }
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self))]
     pub async fn attach_app_interface(&mut self, happ_port: u16) -> Result<AdminResponse> {
         info!(port = ?happ_port, "starting app interface");
         let msg = AdminRequest::AttachAppInterface {
@@ -112,7 +112,7 @@ impl AdminWebsocket {
         self.send(msg).await
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self))]
     async fn send(&mut self, msg: AdminRequest) -> Result<AdminResponse> {
         let response = self
             .tx

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -61,24 +61,24 @@ impl AdminWebsocket {
 
     #[instrument(
         skip(self, happ, agent_key),
-        fields(?happ.installed_app_id),
+        fields(?happ.app_id),
     )]
     pub async fn install_happ(&mut self, happ: &Happ, agent_key: AgentPubKey) -> Result<()> {
         debug!(?agent_key);
         if happ.dna_url.is_some() {
             self.instance_dna_for_agent(happ, agent_key).await?;
         } else {
-            debug!(?happ.installed_app_id, "dna_url == None, skipping DNA installation")
+            debug!(?happ.app_id, "dna_url == None, skipping DNA installation")
         }
         self.activate_app(happ).await?;
-        info!(?happ.installed_app_id, "installed hApp");
+        info!(?happ.app_id, "installed hApp");
         Ok(())
     }
 
     #[instrument(
         err,
         skip(self, happ, agent_key),
-        fields(?happ.installed_app_id)
+        fields(?happ.app_id)
     )]
     async fn instance_dna_for_agent(
         &mut self,


### PR DESCRIPTION
- [x] `list_installed_happs`:
    - [x] write
    - [x] use
- [x] Do once on startup:
    - [x] Start interface
- [x] Generate agent key only if necessary and cache one value across all possible dna installations
- [x] Add `version` field to `Happ`
    - [x] Use `id:version` format in requests
- [x] Bump holochain to version in Holo-Host/holo-nixpkgs#632
- [x] retry policy

Other breaking changes:

- `UI_STORE_FOLDER` needs to be set by HPOS