### PR TITLE
Add UUID as param in config and use RegisterDNA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arrayref"
@@ -267,9 +267,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41aa2ec95ca3b5c54cf73c91acf06d24f4495d5f1b1c12506ae3483d646177ac"
+checksum = "5a4bad0c5981acc24bc09e532f35160f952e35422603f0563cd7a73c2c2e65a0"
 
 [[package]]
 name = "byteorder"
@@ -282,6 +282,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -495,7 +501,7 @@ dependencies = [
  "cranelift-entity",
  "gimli 0.20.0",
  "log",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "target-lexicon 0.10.0",
  "thiserror",
 ]
@@ -935,7 +941,7 @@ dependencies = [
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -1041,9 +1047,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1056,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1066,15 +1072,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1083,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-lite"
@@ -1098,15 +1104,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.1",
+ "pin-project-lite 0.2.4",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1116,24 +1122,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1142,7 +1148,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.1",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1233,7 +1239,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1256,7 +1262,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -1271,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "holochain_zome_types",
  "paste 1.0.3",
@@ -1307,7 +1313,7 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1320,8 +1326,8 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+version = "0.0.100"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1385,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "holochain_cascade"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "derive_more",
  "either",
@@ -1414,22 +1420,28 @@ dependencies = [
 [[package]]
 name = "holochain_conductor_api"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
+ "derive_more",
+ "directories 2.0.2",
  "holo_hash",
+ "holochain_p2p",
  "holochain_serialized_bytes",
  "holochain_types",
  "holochain_zome_types",
  "kitsune_p2p",
  "serde",
  "serde_derive",
+ "serde_yaml",
+ "thiserror",
  "tracing",
+ "url2",
 ]
 
 [[package]]
 name = "holochain_keystore"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "ghost_actor",
  "holo_hash",
@@ -1447,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "holochain_lmdb"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1483,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "holochain_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "async-trait",
  "fixt",
@@ -1533,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "holochain_state"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "byteorder",
  "chrono",
@@ -1561,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "holochain_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1599,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_test_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1652,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "holochain_websocket"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "futures",
  "holochain_serialized_bytes",
@@ -1671,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -1687,11 +1699,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -1702,7 +1714,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1730,7 +1742,7 @@ dependencies = [
  "serde_derive",
  "termcolor",
  "toml",
- "uuid 0.8.1",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1739,7 +1751,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1749,7 +1761,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.3",
+ "pin-project 1.0.4",
  "socket2",
  "tokio",
  "tower-service",
@@ -1763,7 +1775,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
  "tokio",
@@ -1832,11 +1844,12 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514b79a9791d88f90889bd38a88dc43a6058b3ec72a8930a817c6e59fa9e4927"
+checksum = "67bcf81cd7094c6827cec657c53f0d22dec1afed5eeccb16118f5763a7bbd869"
 dependencies = [
  "ahash 0.6.2",
+ "atty",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -1859,7 +1872,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -1892,7 +1905,7 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "crossbeam-utils",
  "curl",
  "curl-sys",
@@ -1948,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "derive_more",
  "fixt",
@@ -1973,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_proxy"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
@@ -1997,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_transport_quic"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "futures",
  "if-addrs",
@@ -2016,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "kitsune_p2p_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=5daac31fe21f5d10c192bbe208f0b11f8ee67d88#5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "derive_more",
  "futures",
@@ -2108,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lmdb-rkv"
@@ -2153,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -2588,8 +2601,8 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi",
  "libc",
- "redox_syscall",
- "smallvec 1.6.0",
+ "redox_syscall 0.1.57",
+ "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
 
@@ -2602,8 +2615,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
- "smallvec 1.6.0",
+ "redox_syscall 0.1.57",
+ "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
 
@@ -2666,11 +2679,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83804639aad6ba65345661744708855f9fbcb71176ea8d28d05aeb11d975e7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.3",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -2686,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bcc46b8f73443d15bc1c5fecbb315718491fa9187fa483f0e359323cde8b3a"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2703,9 +2716,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36743d754ccdf9954c2e352ce2d4b106e024c814f6499c2dadff80da9a442d8"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -2796,9 +2809,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2824,7 +2837,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "err-derive",
  "futures",
  "libc",
@@ -2842,7 +2855,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "ct-logs",
  "err-derive",
  "rand 0.7.3",
@@ -2909,6 +2922,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2951,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2953,6 +2988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,6 +3012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -3087,13 +3140,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.16",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -3141,7 +3203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3157,7 +3219,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.1",
+ "pin-project-lite 0.2.4",
  "serde",
  "serde_urlencoded",
  "tokio",
@@ -3209,7 +3271,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "url 2.2.0",
- "uuid 0.8.1",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3562,18 +3624,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -3720,14 +3782,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3819,7 +3881,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -3879,7 +3941,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -4004,7 +4066,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -4032,7 +4094,7 @@ checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",
@@ -4173,11 +4235,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand 0.7.3",
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -4360,7 +4422,7 @@ checksum = "c23f2824f354a00a77e4b040eef6e1d4c595a8a3e9013bad65199cc8dade9a5a"
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "target-lexicon 0.10.0",
 ]
 
@@ -4415,7 +4477,7 @@ dependencies = [
  "serde-bench",
  "serde_bytes",
  "serde_derive",
- "smallvec 0.6.13",
+ "smallvec 0.6.14",
  "target-lexicon 0.9.0",
  "wasmparser",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ url = "2.2"
 
 [dependencies.holochain]
 git = "https://github.com/holochain/holochain"
-rev = "5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+rev = "ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 package = "holochain"
 default-features = false
 
 [dependencies.holochain_types]
 git = "https://github.com/holochain/holochain"
-rev = "5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+rev = "ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 package = "holochain_types"
 
 [dependencies.holochain_websocket]
 git = "https://github.com/holochain/holochain"
-rev = "5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
+rev = "ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 package = "holochain_websocket"
 
 # Holochain requires a patch to crates.io registry

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ pub struct Happ {
     pub dna_url: Option<Url>,
     pub ui_path: Option<PathBuf>,
     pub dna_path: Option<PathBuf>,
+    pub uuid: Option<String>
 }
 
 impl Happ {

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ pub struct Happ {
     pub dna_url: Option<Url>,
     pub ui_path: Option<PathBuf>,
     pub dna_path: Option<PathBuf>,
-    pub uuid: Option<String>
+    pub uuid: Option<String>,
 }
 
 impl Happ {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -6,7 +6,7 @@ use std::{env, fs};
 use anyhow::{anyhow, Context, Result};
 use holochain::conductor::api::{AdminRequest, AdminResponse, AppRequest, AppResponse};
 use holochain_types::{
-    app::{InstallAppDnaPayload, InstallAppPayload, InstalledApp, InstalledAppId},
+    app::{InstallAppDnaPayload, InstallAppPayload, InstalledApp, InstalledAppId, RegisterDnaPayload, DnaSource},
     dna::AgentPubKey,
 };
 use holochain_websocket::{websocket_connect, WebsocketConfig, WebsocketSender};
@@ -122,20 +122,37 @@ impl AdminWebsocket {
                 .await
                 .context("failed to download DNA archive")?,
         };
-        let dna = InstallAppDnaPayload {
-            nick: happ.id_with_version(),
-            path,
+
+        // register the DNA so we can pass in a uuid
+        let dna = RegisterDnaPayload {
+            uuid: happ.uuid.clone(),
+            source: DnaSource::Path(path.into()),
             properties: None,
-            membrane_proof: None,
         };
-        let payload = InstallAppPayload {
-            installed_app_id: happ.id_with_version(),
-            agent_key,
-            dnas: vec![dna],
-        };
-        let msg = AdminRequest::InstallApp(Box::new(payload));
+
+        let msg = AdminRequest::RegisterDna(Box::new(dna));
         let response = self.send(msg).await?;
-        Ok(response)
+        if let AdminResponse::DnaRegistered(hash) = response {
+
+            // install the happ using the registered DNA
+            let dna = InstallAppDnaPayload {
+                nick: happ.id_with_version(),
+                path: None,
+                hash: Some(hash),
+                properties: None,
+                membrane_proof: None,
+            };
+            let payload = InstallAppPayload {
+                installed_app_id: happ.id_with_version(),
+                agent_key,
+                dnas: vec![dna],
+            };
+            let msg = AdminRequest::InstallApp(Box::new(payload));
+            let response = self.send(msg).await?;
+            Ok(response)
+        } else {
+            unreachable!()
+        }
     }
 
     #[instrument(skip(self), err)]

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -6,7 +6,10 @@ use std::{env, fs};
 use anyhow::{anyhow, Context, Result};
 use holochain::conductor::api::{AdminRequest, AdminResponse, AppRequest, AppResponse};
 use holochain_types::{
-    app::{InstallAppDnaPayload, InstallAppPayload, InstalledApp, InstalledAppId, RegisterDnaPayload, DnaSource},
+    app::{
+        DnaSource, InstallAppDnaPayload, InstallAppPayload, InstalledApp, InstalledAppId,
+        RegisterDnaPayload,
+    },
     dna::AgentPubKey,
 };
 use holochain_websocket::{websocket_connect, WebsocketConfig, WebsocketSender};
@@ -133,7 +136,6 @@ impl AdminWebsocket {
         let msg = AdminRequest::RegisterDna(Box::new(dna));
         let response = self.send(msg).await?;
         if let AdminResponse::DnaRegistered(hash) = response {
-
             // install the happ using the registered DNA
             let dna = InstallAppDnaPayload {
                 nick: happ.id_with_version(),


### PR DESCRIPTION
This PR allows us to set a UUID in the config-file so as to bump hash-space without having to recompile the DNA.

This requires updating to latest holochain and use the RegisterDna function along with InstallApp