### PR TITLE
Fix installed app id to include UUID

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,34 @@ pub struct Happ {
 }
 
 impl Happ {
-    pub fn id_with_version(&self) -> String {
-        format!("{}:{}", self.app_id, self.version)
+    /// generates the installed app id that should be used
+    /// based on the version and the uuid provided in the config fiel
+    pub fn id_from_config(&self) -> String {
+        if let Some(ref uuid) = self.uuid {
+            format!("{}:{}:{}", self.app_id, self.version, uuid)
+        } else {
+            format!("{}:{}", self.app_id, self.version)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_install_app_id_format() {
+        let mut cfg = Happ {
+            app_id: "x".into(),
+            version: String::from("1"),
+            ui_url: None,
+            dna_url: None,
+            dna_path: None,
+            ui_path: None,
+            uuid: None,
+        };
+        assert_eq!(cfg.id_from_config(), String::from("x:1"));
+        cfg.uuid = Some(String::from("001"));
+        assert_eq!(cfg.id_from_config(), String::from("x:1:001"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn install_happs(happ_file: &HappFile, config: &Config) -> Result<()> 
 
     for happ in &happs_to_install {
         info!("Installing app {}", happ.app_id);
-        if active_happs.contains(&happ.id_with_version()) {
+        if active_happs.contains(&happ.id_from_config()) {
             info!("App already installed, just downloading UI");
             install_ui(happ, config).await?;
         } else {
@@ -73,7 +73,7 @@ pub async fn install_happs(happ_file: &HappFile, config: &Config) -> Result<()> 
 
     let happs_to_keep: HappIds = happs_to_install
         .iter()
-        .map(|happ| happ.id_with_version())
+        .map(|happ| happ.id_from_config())
         .collect();
 
     for app in &*active_happs {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -138,14 +138,14 @@ impl AdminWebsocket {
         if let AdminResponse::DnaRegistered(hash) = response {
             // install the happ using the registered DNA
             let dna = InstallAppDnaPayload {
-                nick: happ.id_with_version(),
+                nick: happ.id_from_config(),
                 path: None,
                 hash: Some(hash),
                 properties: None,
                 membrane_proof: None,
             };
             let payload = InstallAppPayload {
-                installed_app_id: happ.id_with_version(),
+                installed_app_id: happ.id_from_config(),
                 agent_key,
                 dnas: vec![dna],
             };
@@ -160,7 +160,7 @@ impl AdminWebsocket {
     #[instrument(skip(self), err)]
     async fn activate_app(&mut self, happ: &Happ) -> Result<AdminResponse> {
         let msg = AdminRequest::ActivateApp {
-            installed_app_id: happ.id_with_version(),
+            installed_app_id: happ.id_from_config(),
         };
         self.send(msg).await
     }


### PR DESCRIPTION
install app id now includes UUID if given for a happ.  This allows bumping hash-spaces without recompiling DNAs, but means that UI's have to expect the app_id changes.